### PR TITLE
Remove unused peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,6 @@
     "ci": "npm run format && git diff --exit-code && npm run lint && npm test",
     "build": "rm -rf lib && babel src --out-dir lib"
   },
-  "peerDependencies": {
-    "graphql": ">=0.6.0 <1.0.0"
-  },
   "devDependencies": {
     "babel-cli": "^6.23.0",
     "babel-core": "^6.23.1",


### PR DESCRIPTION
## About

I noticed there's a peer dependency constraint (as noted [here](https://github.com/calebmer/graphql-resolve-batch/issues/12)) which is unnecessary as the package doesn't ever import `graphql` at runtime.

This PR removes that constraint and the maintenance burden of supporting differing versions of graphql.js

Fix #12 